### PR TITLE
Follow redirects

### DIFF
--- a/sitemap-urls.sh
+++ b/sitemap-urls.sh
@@ -30,9 +30,9 @@ fetch_xml() {
 
   if [[ $filename == *.gz ]]
   then
-    curl -s $url | gunzip -c
+    curl -sL $url | gunzip -c
   else
-    curl -s $url
+    curl -sL $url
   fi
 }
 


### PR DESCRIPTION
If the given URL for a sitemap will lead to a HTTP redirect, follow this redirect to get to the final destination.